### PR TITLE
Fix relative path in bin script on windows

### DIFF
--- a/src/NodeJsInstaller.php
+++ b/src/NodeJsInstaller.php
@@ -228,6 +228,7 @@ class NodeJsInstaller
         }
 
         $fullTargetDir = realpath($targetDir);
+        $binDir = realpath($binDir);
 
         if (!Environment::isWindows()) {
             $this->createBinScript($binDir, $fullTargetDir, 'node', $isLocal);


### PR DESCRIPTION
Fixes issue with realpath() returning upper case drive letter, with that creation
of relative path doesn't work correctly.

Use realpath also for $binDir to have both in the same casing.

Fixes also possible problem when realpath for $targetDir resolves symlinks.
