### PR TITLE
Increase priority for events to install before other plugins

### DIFF
--- a/src/NodeJsPlugin.php
+++ b/src/NodeJsPlugin.php
@@ -41,10 +41,10 @@ class NodeJsPlugin implements PluginInterface, EventSubscriberInterface
     {
         return array(
             ScriptEvents::POST_INSTALL_CMD => array(
-                array('onPostUpdateInstall', -1),
+                array('onPostUpdateInstall', 1),
             ),
             ScriptEvents::POST_UPDATE_CMD => array(
-                array('onPostUpdateInstall', -1),
+                array('onPostUpdateInstall', 1),
             ),
         );
     }


### PR DESCRIPTION
Fixes compatibility with https://github.com/koala-framework/composer-extra-assets.

> An optional priority integer (higher equals more important, and therefore that the listener
> will be triggered earlier) that determines when a listener is triggered versus other listeners
> (defaults to 0). If two listeners have the same priority, they are executed in the order that
> they were added to the dispatcher.

Changing the priority from -1 to 1 will make sure this event is executed before composer-extra-assets, which uses priority 0.

Fixes #11
