### PR TITLE
Fix composer plugin api requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
     	"php": ">=5.3.0",
-        "composer-plugin-api": "~1.0.0",
+        "composer-plugin-api": "^1.0.0",
         "ext-openssl": "*"
     },
     "require-dev": {


### PR DESCRIPTION
Without this patch if we bump the composer plugin API to 1.1+ your plugin won't be installable anymore.
