### PR TITLE
Replace short array syntax (not supported in 5.3)

### DIFF
--- a/src/NodeJsPlugin.php
+++ b/src/NodeJsPlugin.php
@@ -233,7 +233,7 @@ class NodeJsPlugin implements PluginInterface, EventSubscriberInterface
 
         // Now, let's remove the links
         $this->verboseLog("Removing NodeJS and NPM links from Composer bin directory");
-        foreach (["node", "npm", "node.bat", "npm.bat"] as $file) {
+        foreach (array("node", "npm", "node.bat", "npm.bat") as $file) {
             $realFile = $binDir.DIRECTORY_SEPARATOR.$file;
             if (file_exists($realFile)) {
                 $fileSystem->remove($realFile);


### PR DESCRIPTION
Short array syntax added in PHP 5.4
http://php.net/manual/en/language.types.array.php
