### PR TITLE
fix when composer bin dir is in path

### DIFF
--- a/src/NodeJsInstaller.php
+++ b/src/NodeJsInstaller.php
@@ -111,7 +111,7 @@ class NodeJsInstaller
      *
      * @return null|string
      */
-    public function getNodeJsLocalInstallVersion()
+    public function getNodeJsLocalInstallVersion($binDir)
     {
         $returnCode = 0;
         $output = "";
@@ -121,11 +121,7 @@ class NodeJsInstaller
 
         ob_start();
 
-        if (!Environment::isWindows()) {
-            $version = exec("vendor/bin/node -v 2>&1", $output, $returnCode);
-        } else {
-            $version = exec("vendor\\bin\\node -v 2>&1", $output, $returnCode);
-        }
+        $version = exec($binDir.DIRECTORY_SEPARATOR.'node -v 2>&1', $output, $returnCode);
 
         ob_end_clean();
 
@@ -332,7 +328,14 @@ class NodeJsInstaller
             } else {
                 $path = $this->getGlobalInstallPath($target);
             }
+
+            if (strpos($path, $binDir) === 0) {
+                // we found the local installation that already exists.
+
+                return;
+            }
         }
+
 
         file_put_contents($binDir.'/'.$scriptName, sprintf($content, $path));
         chmod($binDir.'/'.$scriptName, 0755);

--- a/src/NodeJsPlugin.php
+++ b/src/NodeJsPlugin.php
@@ -90,7 +90,7 @@ class NodeJsPlugin implements PluginInterface, EventSubscriberInterface
 
         if ($settings['forceLocal']) {
             $this->verboseLog(" - Forcing local NodeJS install.");
-            $this->installLocalVersion($nodeJsInstaller, $versionConstraint, $settings['targetDir']);
+            $this->installLocalVersion($binDir, $nodeJsInstaller, $versionConstraint, $settings['targetDir']);
             $isLocal = true;
         } else {
             $globalVersion = $nodeJsInstaller->getNodeJsGlobalInstallVersion();
@@ -101,17 +101,17 @@ class NodeJsPlugin implements PluginInterface, EventSubscriberInterface
 
                 if (!$npmPath) {
                     $this->verboseLog(" - No NPM install found");
-                    $this->installLocalVersion($nodeJsInstaller, $versionConstraint, $settings['targetDir']);
+                    $this->installLocalVersion($binDir, $nodeJsInstaller, $versionConstraint, $settings['targetDir']);
                     $isLocal = true;
                 } elseif (!$nodeJsVersionMatcher->isVersionMatching($globalVersion, $versionConstraint)) {
-                    $this->installLocalVersion($nodeJsInstaller, $versionConstraint, $settings['targetDir']);
+                    $this->installLocalVersion($binDir, $nodeJsInstaller, $versionConstraint, $settings['targetDir']);
                     $isLocal = true;
                 } else {
                     $this->verboseLog(" - Global NodeJS install matches constraint ".$versionConstraint);
                 }
             } else {
                 $this->verboseLog(" - No global NodeJS install found");
-                $this->installLocalVersion($nodeJsInstaller, $versionConstraint, $settings['targetDir']);
+                $this->installLocalVersion($binDir, $nodeJsInstaller, $versionConstraint, $settings['targetDir']);
                 $isLocal = true;
             }
         }
@@ -139,16 +139,17 @@ class NodeJsPlugin implements PluginInterface, EventSubscriberInterface
     /**
      * Checks local NodeJS version, performs install if needed.
      *
+     * @param  string                   $binDir
      * @param  NodeJsInstaller          $nodeJsInstaller
      * @param  string                   $versionConstraint
      * @param  string                   $targetDir
      * @throws NodeJsInstallerException
      */
-    private function installLocalVersion(NodeJsInstaller $nodeJsInstaller, $versionConstraint, $targetDir)
+    private function installLocalVersion($binDir, NodeJsInstaller $nodeJsInstaller, $versionConstraint, $targetDir)
     {
         $nodeJsVersionMatcher = new NodeJsVersionMatcher();
 
-        $localVersion = $nodeJsInstaller->getNodeJsLocalInstallVersion();
+        $localVersion = $nodeJsInstaller->getNodeJsLocalInstallVersion($binDir);
         if ($localVersion !== null) {
             $this->verboseLog(" - Local NodeJS install found: v".$localVersion);
 


### PR DESCRIPTION
thanks a lot for this installer, this just saved us from building a custom cloudfoundry buildpack!

we noticed two problems that this PR fixes:
- When the bin-dir of composer is configured to somewhere else than vendor/bin, the local installation is not found
- When the composer bin directory is in $PATH, the local installation is considered global, leading to write a script that endlessly calls itself.
