### PR TITLE
Setup Dockunit for comprehensive continuous integration tests

### DIFF
--- a/Dockunit.json
+++ b/Dockunit.json
@@ -1,0 +1,20 @@
+{
+  "containers": [
+    {
+      "prettyName": "php 7.0-rc-4",
+      "image": "dockunit\/prebuilt-images:php-mysql-phpunit-7.0-rc-4-fpm",
+      "testCommand": "phpunit",
+      "beforeScripts": [
+        "composer install"
+      ]
+    },
+    {
+      "prettyName": "php 5.6",
+      "image": "dockunit\/prebuilt-images:php-mysql-phpunit-5.6-fpm",
+      "testCommand": "phpunit",
+      "beforeScripts": [
+        "composer install"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
[Dockunit](https://dockunit.io) is a continuous integration service built to be container based. It is super helpful because you can build and distribute your test environments from scratch and run tests locally with ease.

This PR tests in PHP latest stable and 5.6. Incorporating Dockunit now will make it easier to test more complex environments in the future since it is Docker container based.

Assuming the PR is accepted, I'll send another with the Dockunit status badge for the README.md. You can see the [current Dockunit status of the project here](https://dockunit.io/projects/tlovett1/nodejs-installer).
