### PR TITLE
Alias packages can now be used

### DIFF
--- a/src/NodeJsPlugin.php
+++ b/src/NodeJsPlugin.php
@@ -2,6 +2,7 @@
 namespace Mouf\NodeJsInstaller;
 
 use Composer\Composer;
+use Composer\Package\AliasPackage;
 use Composer\Package\CompletePackage;
 use Composer\Script\Event;
 use Composer\EventDispatcher\EventSubscriberInterface;
@@ -200,7 +201,9 @@ class NodeJsPlugin implements PluginInterface, EventSubscriberInterface
         $versions = array();
 
         foreach ($packagesList as $package) {
-            /* @var $package PackageInterface */
+            if ($package instanceof AliasPackage) {
+                $package = $package->getAliasOf();
+            }
             if ($package instanceof CompletePackage) {
                 $extra = $package->getExtra();
                 if (isset($extra['mouf']['nodejs']['version'])) {


### PR DESCRIPTION
Hi everyone.

A quick fix. The problem was the banch alias. In my case, I have a symfony application, and the composer.json contains a banch alias : 

``` json
{
    ...
    "extra": {
        "symfony-app-dir": "app",
        "symfony-web-dir": "web",
        "symfony-assets-install": "relative",
        "mouf": {
            "nodejs": {
                "version": ">4.0",
                "forceLocal": true
            }
        }
    }
```

In that case, the instance of package returns by composer is a `RootAliasPackage` wrapper, so I've just unwrapped the package.
