### PR TITLE
Listen to a custom command

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,24 @@ Available options:
   is not impacted by this option.  
   This option is only available in the root package.  
   *Default value: false*
+
+
+Custom script
+-------------
+
+The installer listens to the following composer scripts to be launched:
+```
+{
+    "post-install-cmd": {
+        // ...
+    },
+    "post-update-cmd": {
+        // ...
+    }
+}
+```
+
+If you need to launch the installer manually, you can run the following command:
+```
+$ composer run-script download-nodejs
+```

--- a/src/NodeJsPlugin.php
+++ b/src/NodeJsPlugin.php
@@ -22,6 +22,8 @@ class NodeJsPlugin implements PluginInterface, EventSubscriberInterface
 
     protected $composer;
 
+    const DOWNLOAD_NODEJS_EVENT = 'download-nodejs';
+
     /**
      * @var IOInterface
      */
@@ -47,6 +49,9 @@ class NodeJsPlugin implements PluginInterface, EventSubscriberInterface
             ScriptEvents::POST_UPDATE_CMD => array(
                 array('onPostUpdateInstall', 1),
             ),
+            self::DOWNLOAD_NODEJS_EVENT => array(
+                array('onPostUpdateInstall', 1)
+            )
         );
     }
 


### PR DESCRIPTION
Listening to this event will allow us to launch the download manually (e.g. when a `composer --no-scripts` command is launched)
