### PR TITLE
Detect aarch64 for Arm Platform

### DIFF
--- a/src/Environment.php
+++ b/src/Environment.php
@@ -43,7 +43,7 @@ class Environment
      */
     public static function isArm()
     {
-        return strpos(strtolower(php_uname("m")), "arm") === 0;
+        return (strpos(strtolower(php_uname("m")), "arm") === 0 || php_uname("m") === 'aarch64');
     }
 
     /**


### PR DESCRIPTION
I'd like to say a big thank you for your software.
This pull request will detect aarch64 for Arm Platform.

(nodejs-installer v1.0.14 doesn't detect aarch64.)
```
$ php -r 'print php_uname("m")."\n";'
aarch64
```