### PR TITLE
Added --no-same-owner flag when extracting the NodeJs archive

### DIFF
--- a/src/NodeJsInstaller.php
+++ b/src/NodeJsInstaller.php
@@ -279,10 +279,11 @@ class NodeJsInstaller
     {
         // Note: we cannot use PharData class because it does not keeps symbolic links.
         // Also, --strip 1 allows us to remove the first directory.
+        // --no-same-owner is used to extract the files as the current user, even if the current user is root.
 
         $output = $return_var = null;
 
-        exec("tar -xvf ".$tarGzFile." -C ".escapeshellarg($targetDir)." --strip 1", $output, $return_var);
+        exec("tar -xvf ".$tarGzFile." -C ".escapeshellarg($targetDir)." --strip 1 --no-same-owner", $output, $return_var);
 
         if ($return_var !== 0) {
             throw new NodeJsInstallerException("An error occurred while untaring NodeJS ($tarGzFile) to $targetDir");


### PR DESCRIPTION
Added --no-same-owner flag when extracting the NodeJs archive, so that it can behaves as expected when composer runs as root.

### Rationale

When `tar` extracts an archive as root, it attempts to set the owner UID/GID of the extracted files to the UID/GID, which is for the NodeJS archives is 500.

For the NodeJS iInstaller, this behaviour is not desirable, as it results in the extracted files being owned by a different user than the user that runs composer commands. It can even result in the failure to extract.

Although normally composer shouldn't be run as root, this is not necessarily true for applications that run in containers, such as Docker containers.

### Solution

Add the `--no-same-owner` flag to the `tar` command, so that it will behave identical regardless of whether composer runs as root or as a normal user.

For reference, see https://linux.die.net/man/1/tar