### PR TITLE
Add context options for requests in composer extra configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ A number of options are available to customize NodeJS installation:
                 "version": "~0.12",
                 "targetDir": "vendor/nodejs/nodejs",
                 "forceLocal": false
+            },
+            "request_options": {
+                "http": {
+                    "proxy": "http:http://example.webproxy.org"
+                }
             }
         }
     }
@@ -82,7 +87,7 @@ Available options:
   is not impacted by this option.  
   This option is only available in the root package.  
   *Default value: false*
-
+- **request_options** (array): Build context request options array. @ref https://www.php.net/manual/en/context.php
 
 Custom script
 -------------

--- a/src/NodeJsInstaller.php
+++ b/src/NodeJsInstaller.php
@@ -193,7 +193,7 @@ class NodeJsInstaller
      * @param  string                   $targetDirectory
      * @throws NodeJsInstallerException
      */
-    public function install($version, $targetDirectory)
+    public function install($version, $targetDirectory, $progress = true, $requestOptions = array())
     {
         $this->io->write("Installing <info>NodeJS v".$version."</info>");
         $url = $this->getNodeJSUrl($version);
@@ -203,7 +203,7 @@ class NodeJsInstaller
 
         $fileName = 'vendor/'.pathinfo(parse_url($url, PHP_URL_PATH), PATHINFO_BASENAME);
 
-        $this->rfs->copy(parse_url($url, PHP_URL_HOST), $url, $fileName);
+        $this->rfs->copy(parse_url($url, PHP_URL_HOST), $url, $fileName, $progress, $requestOptions);
 
         if (!file_exists($fileName)) {
             throw new \UnexpectedValueException($url.' could not be saved to '.$fileName.', make sure the'
@@ -231,7 +231,7 @@ class NodeJsInstaller
             // We have to download the latest available version in a bin for Windows, then upgrade it:
             $url = "https://nodejs.org/dist/npm/npm-1.4.12.zip";
             $npmFileName = "vendor/npm-1.4.12.zip";
-            $this->rfs->copy(parse_url($url, PHP_URL_HOST), $url, $npmFileName);
+            $this->rfs->copy(parse_url($url, PHP_URL_HOST), $url, $npmFileName, $progress, $requestOptions);
 
             $this->unzip($npmFileName, $targetDirectory);
 

--- a/src/NodeJsVersionsLister.php
+++ b/src/NodeJsVersionsLister.php
@@ -15,7 +15,15 @@ class NodeJsVersionsLister
      */
     private $io;
 
+    /**
+     * @var RemoteFilesystem
+     */
     protected $rfs;
+
+    /**
+     * @var array
+     */
+    protected $extra;
 
     const NODEJS_DIST_URL = "https://nodejs.org/dist/";
 
@@ -23,12 +31,19 @@ class NodeJsVersionsLister
     {
         $this->io = $io;
         $this->rfs = new RemoteFilesystem($io, $composer->getConfig());
+        $this->extra = $composer->getPackage()->getExtra();
     }
 
     public function getList()
     {
+        $requestOptions = array();
+
+        if (isset($this->extra['mouf']['request_options'])) {
+            $requestOptions = $this->extra['mouf']['request_options'];
+        }
+        
         // Let's download the content of HTML page https://nodejs.org/dist/
-        $html = $this->rfs->getContents(parse_url(self::NODEJS_DIST_URL, PHP_URL_HOST), self::NODEJS_DIST_URL, false);
+        $html = $this->rfs->getContents(parse_url(self::NODEJS_DIST_URL, PHP_URL_HOST), self::NODEJS_DIST_URL, false, $requestOptions);
 
         // Now, let's parse it!
         $matches = array();


### PR DESCRIPTION
I work in an org that intercepts SSL requests and I unfortunately require special context values for many requests. 
Because the composer RemoteFilesystem object is not using a curl object, which can be controlled with a global curlrc file, the only way to get things to work is to pass in certain context options. I specifically need SSL context options for the internal SSL cert that is being used.